### PR TITLE
Fix workflow trigger: add tags to top-level trigger

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ name: Pickbox CI/CD
 on:
   push:
     branches: [ "main", "develop" ]
+    tags: [ "*" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The workflow was not triggering on tag pushes because the top-level 'on' section only included branch pushes. Tag pushes were ignored entirely, so the release job conditions were never evaluated.

This adds 'tags: ["*"]' to allow the workflow to trigger on any tag push.